### PR TITLE
153 hotfix 13   random crash when finishing wave day announcment

### DIFF
--- a/Source/DreadNight/Private/Subsystems/World/WaveWorldSubsystem.cpp
+++ b/Source/DreadNight/Private/Subsystems/World/WaveWorldSubsystem.cpp
@@ -61,7 +61,7 @@ void UWaveWorldSubsystem::RegisterSpawner(ASpawner* Spawn)
 	SpawnerList.Push(Spawn);
 }
 
-void UWaveWorldSubsystem::SpawnMonster()
+void UWaveWorldSubsystem::SpawnWave()
 {
 	for (FWaveMonsterData& Monster : BaseWorldSettings->WaveSystemData->WaveList[WaveIndex].MonsterList)
 	{

--- a/Source/DreadNight/Public/Subsystems/World/WaveWorldSubsystem.h
+++ b/Source/DreadNight/Public/Subsystems/World/WaveWorldSubsystem.h
@@ -44,7 +44,7 @@ public:
 
 	void RegisterSpawner(ASpawner* Spawn);
 
-	void SpawnMonster();
+	void SpawnWave();
 
 	UFUNCTION()
 	void MonsterDeath(AActor* Monster);


### PR DESCRIPTION
This pull request refactors the monster spawning logic in the `UWaveWorldSubsystem` class to improve code organization and maintainability. The main change is the extraction of the monster spawning code into a new `SpawnWave()` method, which is now called during the night start event.

**Refactoring and Code Organization:**

* Extracted the monster spawning logic from `OnNightStart()` into a new method `SpawnWave()`, improving code readability and separation of concerns. (`WaveWorldSubsystem.cpp` and `WaveWorldSubsystem.h`) [[1]](diffhunk://#diff-5ed551a14d751f25b92e89d797d019f459cdd4f7e201a8567c47b2b3449187a1L36-R36) [[2]](diffhunk://#diff-5ed551a14d751f25b92e89d797d019f459cdd4f7e201a8567c47b2b3449187a1R64-R81) [[3]](diffhunk://#diff-04edf7ad74458f768915635c1353b3dcc8a7e352847f8afb0cf3fceea731f543R47-R48)
* Updated `OnNightStart()` to call `SpawnWave()` instead of containing the spawning logic directly. (`WaveWorldSubsystem.cpp`)
* Declared the new `SpawnWave()` method in the header file. (`WaveWorldSubsystem.h`)