### PR TITLE
HOTFIX - Fix out of range hotbar access

### DIFF
--- a/Source/DreadNight/Private/InventorySystem/InventoryComponent.cpp
+++ b/Source/DreadNight/Private/InventorySystem/InventoryComponent.cpp
@@ -320,3 +320,8 @@ bool UInventoryComponent::IsFull() const
 	
 	return true;
 }
+
+int UInventoryComponent::GetInventoryLimitSize() const
+{
+	return Size;
+}

--- a/Source/DreadNight/Private/Player/CustomPlayerController.cpp
+++ b/Source/DreadNight/Private/Player/CustomPlayerController.cpp
@@ -432,12 +432,17 @@ void ACustomPlayerController::GoBackToPrecedentMenu(const FInputActionValue& Val
 
 void ACustomPlayerController::SelectedHotbar(const FInputActionValue& Value)
 {
-	int index = (int)Value.Get<float>();
+	int Index = (int)Value.Get<float>();
 
-	if (index == -1)
-		index = 0;
+	if (Index >= MyPlayer->GetHotbarInventoryComponent()->GetInventoryLimitSize())
+		return;
 
-	MyPlayer->GetHotbarInventoryComponent()->UseItemAt(index);
+	
+	if (Index == -1)
+		Index = 0;
+
+	
+	MyPlayer->GetHotbarInventoryComponent()->UseItemAt(Index);
 }
 
 void ACustomPlayerController::SaveGame()

--- a/Source/DreadNight/Private/Player/PlayerCharacter.cpp
+++ b/Source/DreadNight/Private/Player/PlayerCharacter.cpp
@@ -164,7 +164,7 @@ UInventoryComponent* APlayerCharacter::GetHotbarInventoryComponent()
 {
 	return HotbarInventoryComponent;
 }
-
+ 
 void APlayerCharacter::EquipWeapon(UItemInstance_Weapon* Weapon)
 {
 	if (Weapon != nullptr)

--- a/Source/DreadNight/Public/InventorySystem/InventoryComponent.h
+++ b/Source/DreadNight/Public/InventorySystem/InventoryComponent.h
@@ -55,6 +55,7 @@ public:
 	bool Contains(UItemDataAsset* Item, int StackNumber) const;
 	bool IsSlotEmpty(int SlotIndex) const;
 	bool IsFull() const;
+	int GetInventoryLimitSize() const;
 	
 	FOnItemAddedEventSignature OnItemAdded;
 	FOnItemRemovedEventSignature OnItemRemoved;

--- a/Source/DreadNight/Public/Player/PlayerCharacter.h
+++ b/Source/DreadNight/Public/Player/PlayerCharacter.h
@@ -139,7 +139,7 @@ public:
 	
 	UFUNCTION()
 	UInventoryComponent* GetHotbarInventoryComponent();
-
+	
 	UFUNCTION()
 	UBowCombatComponent* GetBowCombatComponent();
 	


### PR DESCRIPTION
Introduced GetInventoryLimitSize() to InventoryComponent for retrieving inventory size. Updated CustomPlayerController to prevent hotbar selection out of bounds by checking against the inventory limit. Minor formatting adjustments in PlayerCharacter files.