### PR TITLE
GP-24 - Create a System that respawn collectible resource 

### DIFF
--- a/Source/DreadNight/Private/Subsystems/World/DayCycleSubSystem.cpp
+++ b/Source/DreadNight/Private/Subsystems/World/DayCycleSubSystem.cpp
@@ -75,6 +75,8 @@ void UDayCycleSubSystem::StartDayCycle()
 	FogComponent->SetFogDensity(BaseWorldSettings->DayCycleSystemData->MaximalFogDensity);
 
 	GetWorld()->GetTimerManager().SetTimer(ProcessDayTimer, this, &UDayCycleSubSystem::ProcessDayPerSecond, BaseWorldSettings->DayCycleSystemData->ProcessedTimeInterval, true);
+
+	OnDawnStart.Broadcast();
 }
 
 void UDayCycleSubSystem::ProcessDayPerSecond()

--- a/Source/DreadNight/Public/CollectibleResource/Actor/CollectibleResource.h
+++ b/Source/DreadNight/Public/CollectibleResource/Actor/CollectibleResource.h
@@ -14,6 +14,7 @@ class DREADNIGHT_API ACollectibleResource : public AActor, public IDamageable, p
 public:
 	virtual bool TryApplyDamage(float Damage, AActor* DamageInstigator) override;
 
+	virtual void OnPostLoad(const TMap<FName, ISavableActor*>& SavableActorCache) override;
 private:
 	GENERATED_BODY()
 	GENERATE_GENERIC_SAVABLE_OBJECT()
@@ -23,12 +24,17 @@ public:
 
 protected: 
 	virtual void BeginPlay() override;
-
-	UPROPERTY(EditDefaultsOnly)
-	FVector2D ItemQuantityRange;
+ 
+	UPROPERTY(SaveGame)
+	int CurrentLife = 1;
 
 	UPROPERTY(SaveGame)
-	int CurrentItemQuantity;
+	bool bIsDestroyed;
+	
+	UPROPERTY(SaveGame)
+	int RespawnDayDelay;
+
+	ECollisionEnabled::Type CollisionType;
 
 	UPROPERTY(EditDefaultsOnly)
 	TObjectPtr<UStaticMeshComponent> ResourceMesh;
@@ -39,6 +45,13 @@ protected:
 	void DropItem() const;
 
 	void SetMesh();
+
+	UFUNCTION()
+	void HealCollectible();
+
+	void TemporaryDestroyCollectible();
+
+	void RespawnCollectible();
 public:
 
 	

--- a/Source/DreadNight/Public/Subsystems/World/DayCycleSubSystem.h
+++ b/Source/DreadNight/Public/Subsystems/World/DayCycleSubSystem.h
@@ -96,6 +96,7 @@ protected:
 
 public:
 	FOnNightStartSignature OnNightStart;
+	FOnNightStartSignature OnDawnStart;
 
 	static ThisClass* Get(UObject* WorldContext);
 


### PR DESCRIPTION
Implemented respawn and temporary destruction mechanics for collectible resources, including new state variables and event-driven healing on dawn. Updated the day cycle subsystem to broadcast a dawn event, and refactored resource damage handling to use life-based logic instead of item quantity.