### PR TITLE
HOTIFX-32 - Options UI graphics display bug

### DIFF
--- a/Source/DreadNight/Private/Global/MyGameInstance.cpp
+++ b/Source/DreadNight/Private/Global/MyGameInstance.cpp
@@ -21,6 +21,9 @@ void UMyGameInstance::Init()
 		{
 			MySettings->RunHardwareBenchmark();
 			MySettings->ApplyHardwareBenchmarkResults();
+			
+			MySettings->SetToDefaults();
+            MySettings->ApplyResolutionSettings(false);
 		}
 		else
 		{

--- a/Source/DreadNight/Private/UserWidgets/OptionsWidget.cpp
+++ b/Source/DreadNight/Private/UserWidgets/OptionsWidget.cpp
@@ -48,10 +48,17 @@ void UOptionsWidget::NativeConstruct()
 
 	if (ComboBoxResolution)
 	{
+		FIntPoint CurrentRes = MySettings->GetScreenResolution();
+		
+		if (CurrentRes.X <= 0 || CurrentRes.Y <= 0)
+		{
+			CurrentRes = MySettings->GetDesktopResolution();
+		}
+		
 		SetupComboBox<FIntPoint>(
 			ComboBoxResolution,
 			ResolutionMap,
-			MySettings->GetScreenResolution()
+			CurrentRes
 		);
 
 		ComboBoxResolution->OnSelectionChanged.AddDynamic(this, &UOptionsWidget::OnResolutionChanged);
@@ -155,7 +162,7 @@ void UOptionsWidget::OnResolutionChanged(FString SelectedItem, ESelectInfo::Type
 
 	MySettings->SetScreenResolution(ResolutionMap[SelectedItem]);
 	
-	MySettings->ApplySettings(false);
+	MySettings->ApplyResolutionSettings(false);
 	
 	MySettings->SaveSettings();
 }


### PR DESCRIPTION
After loading the settings, it apply it instantly, so there is no possibility for a default value to survive.
this should fix the problem.
