### PR TITLE
HOTFIX-30 - Handle inventory tooltip better

### DIFF
--- a/Source/DreadNight/Private/Player/CustomPlayerController.cpp
+++ b/Source/DreadNight/Private/Player/CustomPlayerController.cpp
@@ -294,12 +294,8 @@ void ACustomPlayerController::DisplayInventory(const FInputActionValue& Value)
 		HotBar->SetArmorImagesVisibility(ESlateVisibility::Visible);
 	}
 	
-	FVector2D WidgetSize = InventoryWidget->GetDesiredSize();
-	FVector2D ViewportSize = UWidgetLayoutLibrary::GetViewportSize(GetWorld());
-	float OffsetX = ViewportSize.X * 0.016f;
-	float OffsetY = ViewportSize.Y * 0.2f;
-
-	InventoryWidget->SetPositionInViewport(FVector2D((ViewportSize.X - WidgetSize.X) / 2 + OffsetX, (ViewportSize.Y - WidgetSize.Y) / 2 - OffsetY), false);
+	InventoryWidget->SetAnchorsInViewport(FAnchors(0.5f, 0.5f));
+	InventoryWidget->SetAlignmentInViewport(FVector2D(0.5f, 0.5f));
 	SetShowMouseCursor(true);
 
 	PushNewMenu(InventoryWidget, false, [this]

--- a/Source/DreadNight/Private/UI/Widgets/Inventory.cpp
+++ b/Source/DreadNight/Private/UI/Widgets/Inventory.cpp
@@ -112,16 +112,16 @@ void UInventory::OnItemActionCreated(int SlotIndex)
 	
 	const FVector2d MousePos = UWidgetLayoutLibrary::GetMousePositionOnViewport(GetWorld());
 	const FVector2D ViewportSize = UWidgetLayoutLibrary::GetViewportSize(GetWorld());
-	OffsetX = ViewportSize.X * 0.06f;
-	OffsetY = ViewportSize.Y * 0.05f;
-	Offset = FVector2D(OffsetX, OffsetY);
+	float OffsetX = ViewportSize.X * 0.06f;
+	float OffsetY = ViewportSize.Y * 0.05f;
+	WidgetOffset = FVector2D(OffsetX, OffsetY);
 
-	Offset.Y = (MousePos.Y >= ViewportSize.Y / 1.5f ? -OffsetY : OffsetY);
+	WidgetOffset.Y = (MousePos.Y >= ViewportSize.Y / 1.5f ? -OffsetY : OffsetY);
 	
 	InventoryAction = CreateWidget<UInventoryAction>(this, InventoryActionClass);
 	InventoryAction->SetupAction(BindInventoryComponent, BindTargetInventoryComponent, SlotIndex);
 	InventoryAction->AddToViewport();
-	InventoryAction->SetPositionInViewport(MousePos + Offset, false);
+	InventoryAction->SetPositionInViewport(MousePos + WidgetOffset, false);
 	GlobalInventoryAction = InventoryAction;
 	
 	UItemInstance* ItemData = BindInventoryComponent->GetItemAtSlot(SlotIndex);
@@ -173,15 +173,14 @@ void UInventory::OnItemInfoCreated(int SlotIndex)
 	
 	const FVector2d MousePos = UWidgetLayoutLibrary::GetMousePositionOnViewport(GetWorld());
 	const FVector2D ViewportSize = UWidgetLayoutLibrary::GetViewportSize(GetWorld());
-	OffsetX = ViewportSize.X * 0.06f;
-	OffsetY = ViewportSize.Y * 0.05f;
-	Offset = FVector2D(OffsetX, OffsetY);
-
-	Offset.Y = (MousePos.Y >= ViewportSize.Y / 1.5f ? -OffsetY : OffsetY);
-
+	float FixedOffset = 50.f; 
+	WidgetOffset = FVector2D(FixedOffset, FixedOffset);
+    
+	WidgetOffset.Y = (MousePos.Y >= ViewportSize.Y + FixedOffset ? -FixedOffset : FixedOffset);
+	
 	InventoryInfoWidget = CreateWidget<UInventoryInfo>(this, ItemInfoWidgetClass);
 	InventoryInfoWidget->AddToViewport();
-	InventoryInfoWidget->SetPositionInViewport(MousePos + Offset, false);
+	InventoryInfoWidget->SetPositionInViewport(MousePos + WidgetOffset, false);
 	
 	InventoryInfoWidget->GetItemInfoButton()->SetVisibility(ESlateVisibility::Hidden);
 	if (UItemInstance* ItemData = BindInventoryComponent->GetItemAtSlot(SlotIndex))

--- a/Source/DreadNight/Private/UI/Widgets/InventoryAction.cpp
+++ b/Source/DreadNight/Private/UI/Widgets/InventoryAction.cpp
@@ -1,5 +1,5 @@
 #include "UI/Widgets/InventoryAction.h"
-#include "Blueprint/WidgetLayoutLibrary.h"
+#include "Blueprint/SlateBlueprintLibrary.h"
 #include "Items/Data/ItemDataAsset.h"
 
 void UInventoryAction::NativePreConstruct()
@@ -60,17 +60,18 @@ void UInventoryAction::OnTransferPressed()
 	UInventoryQuickAddSlot* QuickAddWidget = CreateWidget<UInventoryQuickAddSlot>(this, InventoryQuickAddWidgetClass);
 	if (TargetInventoryComponent->GetName() == "HotBarInventoryComponent" && QuickAddWidget)
 	{
+		FVector2D PixelPos;
+		FVector2D ViewportPos;
+		float OffsetX = 0.1f;
+		float OffsetY = -190.f;
+		USlateBlueprintLibrary::LocalToViewport(GetWorld(), GetCachedGeometry(), FVector2D(GetCachedGeometry().GetLocalSize().X, 0.f), PixelPos, ViewportPos);
+		
 		QuickAddWidget->SetupMenu(TargetInventoryComponent);
-		
-		const FVector2D ViewportSize = UWidgetLayoutLibrary::GetViewportSize(GetWorld());
-		float OffsetX = ViewportSize.X * 0.135f;
-		float OffsetY = -50.f;
-		FVector2D Offset = FVector2D(OffsetX, OffsetY);
-		
 		QuickAddWidget->OnQuickActionPressedEvent.AddDynamic(this, &UInventoryAction::OnQuickActionPressed);
-		InventoryQuickAddSlot = QuickAddWidget;
 		QuickAddWidget->AddToViewport();
-		QuickAddWidget->SetPositionInViewport(GetCachedGeometry().GetAbsolutePosition() + FVector2D(GetDesiredSize().X, 0.f) + Offset, false);
+		QuickAddWidget->SetPositionInViewport(ViewportPos + FVector2D(GetCachedGeometry().GetLocalSize().X * OffsetX, OffsetY), false);
+		
+		InventoryQuickAddSlot = QuickAddWidget;
 		return;
 	}
 	

--- a/Source/DreadNight/Public/UI/Widgets/Inventory.h
+++ b/Source/DreadNight/Public/UI/Widgets/Inventory.h
@@ -15,9 +15,7 @@ class DREADNIGHT_API UInventory : public UUserWidget
 {
 	GENERATED_BODY()
 private:
-	float OffsetY = 0.0f;
-	float OffsetX = 0.0f;
-	FVector2D Offset = FVector2D(0.0f, 0.0f);
+	FVector2D WidgetOffset = FVector2D(0.0f, 0.0f);
 	inline static TWeakObjectPtr<UInventoryAction> GlobalInventoryAction;
 protected:
 	UPROPERTY(meta =(BindWidgetOptional))


### PR DESCRIPTION
Replaced viewport ratios with dynamic geometry checks
Updated ItemInfo widget to appear above the cursor when near the bottom of the screen
Fixed offset inconsistencies between 1080p, 2K and 4K resolutions
Still isn't 1 : 1 for ItemAction and ItemInfo, but prevents widgets from spawning off-screen regardless resolutions