### PR TITLE
HOTFIX-42 - Building is no longer consumed

### DIFF
--- a/Source/DreadNight/Private/Items/Object/ItemInstance_Building.cpp
+++ b/Source/DreadNight/Private/Items/Object/ItemInstance_Building.cpp
@@ -15,7 +15,6 @@ void UItemInstance_Building::Use(AActor* Player)
 			if (!Controller->IsPlacingBuilding())
 			{
 				Controller->CreateBuilding(GetDataAsset());
-				StackNumber--;
 			}
 		}
 	}

--- a/Source/DreadNight/Public/Player/CustomPlayerController.h
+++ b/Source/DreadNight/Public/Player/CustomPlayerController.h
@@ -300,11 +300,8 @@ private:
 	void ChangeArmorUI(UArmorDataAsset* NewArmor);
 	
 	UFUNCTION()
-	void CancelBuildingPlacement();
+	void StopBuildingPlacement();
 	
-	UFUNCTION()
-	void UpdateBuildingAfterSwap(int Index);
-
 public:
 	void CreateBuilding(UBuildingDataAsset* BuildingData);
 	


### PR DESCRIPTION
For some reason, the item instance building wasn't removing or checking if there was still at least 1 item in the slot, it does now.
Building preview is now refreshed and stopped correctly.
Renamed function CancelBuildingPlacement to StopBuildingPlacement.