### PR TITLE
HOTFIX 53 - The Game freeze when scrolling with an empty hotbar

### DIFF
--- a/Source/DreadNight/Private/Player/CustomPlayerController.cpp
+++ b/Source/DreadNight/Private/Player/CustomPlayerController.cpp
@@ -453,7 +453,8 @@ void ACustomPlayerController::ScrollHotbar(const FInputActionValue& Value)
 	int InventoryLimit = MyPlayer->GetHotbarInventoryComponent()->GetInventoryLimitSize();
 
 	bool validSpot = false;
-	while (!validSpot)
+	int iteration = 0;
+	while (!validSpot && iteration < InventoryLimit)
 	{
 		MyPlayer->CurrentHotbarIndex = (MyPlayer->CurrentHotbarIndex + (int)Value.Get<float>() + InventoryLimit) % InventoryLimit;
 		
@@ -461,8 +462,11 @@ void ACustomPlayerController::ScrollHotbar(const FInputActionValue& Value)
 		{
 			validSpot = true;
 		}
+		iteration++;
 	}
-
+	if (!validSpot)
+		MyPlayer->CurrentHotbarIndex = 0;
+	
 	MyPlayer->GetHotbarInventoryComponent()->OnSelectedHotbarChanged.Broadcast(MyPlayer->CurrentHotbarIndex);
 	
 	ProcessHotbarSlot();


### PR DESCRIPTION
The game doesn't freeze anymore, the infinite while loop is no more